### PR TITLE
Added build for Matlab R2011b on Mac OS X

### DIFF
--- a/Mac-R2011b-Matlab.sublime-build
+++ b/Mac-R2011b-Matlab.sublime-build
@@ -1,0 +1,16 @@
+{
+  "selector": "source.matlab",
+  "cmd": ["/Applications/MATLAB_R2011b.app/bin/matlab", "-nosplash", "<$file_name"],
+
+  "variants": [
+
+    { "cmd": ["/Applications/MATLAB_R2011b.app/bin/matlab", "-nosplash", "-r", "publish('$file_path/$file_name')"],
+      "name": "Publish Matlab"
+    },
+
+    {
+      "cmd": ["open", "$file_path/html/$file_base_name.html"],
+      "name": "Open published Matlab"
+    }
+  ]
+}

--- a/Mac-R2011b-Matlab.sublime-build
+++ b/Mac-R2011b-Matlab.sublime-build
@@ -1,6 +1,6 @@
 {
   "selector": "source.matlab",
-  "cmd": ["/Applications/MATLAB_R2011b.app/bin/matlab", "-nosplash", "<$file_name"],
+  "cmd": ["/Applications/MATLAB_R2011b.app/bin/matlab", "-nosplash", "<$file_name", "2>&1 | grep -v 'exclude an item from Time Machine'"],
 
   "variants": [
 


### PR DESCRIPTION
I also included the command: "2>&1 | grep -v 'exclude an item from Time Machine' " to exclude the strange/erroneous output that R2011b produces when called from the terminal (I've checked, and other users of 2011b also get this output)

i.e. the following lines would be repeated dozens of times without the 2>&1... command:

"MATLAB_maci64[5492:a807] This process is attempting to exclude an item from Time Machine by path without administrator privileges. This is not supported."
